### PR TITLE
feat(attendance): 休憩時間の記録・管理機能を追加

### DIFF
--- a/src/features/attendance/application/services/attendanceService.ts
+++ b/src/features/attendance/application/services/attendanceService.ts
@@ -1,13 +1,27 @@
-import { canClockIn, canClockOut } from "../../domain/logic/attendance"
-import { calculateWorkDuration } from "../../domain/logic/worktime"
+import {
+	canClockIn,
+	canClockOut,
+	canEndBreak,
+	canStartBreak,
+} from "../../domain/logic/attendance"
+import { calculateTotalBreakMinutes, calculateWorkDuration } from "../../domain/logic/worktime"
 import { getClock } from "../../infrastructure/getClock"
 import { getRepository } from "../../infrastructure/getRepository"
 import type {
+	BreakEndResponse,
+	BreakStartResponse,
 	ClockInResponse,
 	ClockOutResponse,
 	HistoryResponse,
 	TodayResponse,
 } from "../../contracts/attendance"
+
+function serializeBreaks(breaks: { breakStart: Date; breakEnd: Date | null }[]) {
+	return breaks.map((b) => ({
+		breakStart: b.breakStart.toISOString(),
+		breakEnd: b.breakEnd ? b.breakEnd.toISOString() : null,
+	}))
+}
 
 export async function getToday(): Promise<TodayResponse> {
 	const clock = getClock()
@@ -21,6 +35,8 @@ export async function getToday(): Promise<TodayResponse> {
 		clockIn: record.clockIn ? record.clockIn.toISOString() : null,
 		clockOut: record.clockOut ? record.clockOut.toISOString() : null,
 		workMinutes: record.workMinutes,
+		breaks: serializeBreaks(record.breaks),
+		breakMinutes: record.breakMinutes,
 	}
 }
 
@@ -59,19 +75,79 @@ export async function clockOut(): Promise<ClockOutResponse> {
 	}
 
 	const now = clock.now()
-	const workDuration = calculateWorkDuration(record.clockIn!, now)
+	const grossDuration = calculateWorkDuration(record.clockIn!, now)
+	const totalBreakMinutes = calculateTotalBreakMinutes(record.breaks)
+	const netWorkMinutes = Math.max(0, grossDuration.totalMinutes - totalBreakMinutes)
+
 	await repository.save({
 		...record,
 		status: "finished",
 		clockOut: now,
-		workMinutes: workDuration.totalMinutes,
+		workMinutes: netWorkMinutes,
+		breakMinutes: totalBreakMinutes,
 	})
 
 	return {
 		success: true,
 		clockOut: now.toISOString(),
-		workMinutes: workDuration.totalMinutes,
+		workMinutes: netWorkMinutes,
+		breakMinutes: totalBreakMinutes,
 		message: "退勤しました",
+	}
+}
+
+export async function startBreak(): Promise<BreakStartResponse> {
+	const clock = getClock()
+	const repository = getRepository()
+	const date = clock.todayString()
+	const record = await repository.getToday(date)
+
+	if (!canStartBreak(record)) {
+		return { success: false, message: "勤務中でないため休憩を開始できません" }
+	}
+
+	const now = clock.now()
+	await repository.save({
+		...record,
+		status: "on_break",
+		breaks: [...record.breaks, { breakStart: now, breakEnd: null }],
+	})
+
+	return {
+		success: true,
+		breakStart: now.toISOString(),
+		message: "休憩を開始しました",
+	}
+}
+
+export async function endBreak(): Promise<BreakEndResponse> {
+	const clock = getClock()
+	const repository = getRepository()
+	const date = clock.todayString()
+	const record = await repository.getToday(date)
+
+	if (!canEndBreak(record)) {
+		return { success: false, message: "休憩中でないため休憩を終了できません" }
+	}
+
+	const now = clock.now()
+	const updatedBreaks = record.breaks.map((b, i) =>
+		i === record.breaks.length - 1 ? { ...b, breakEnd: now } : b,
+	)
+	const totalBreakMinutes = calculateTotalBreakMinutes(updatedBreaks)
+
+	await repository.save({
+		...record,
+		status: "working",
+		breaks: updatedBreaks,
+		breakMinutes: totalBreakMinutes,
+	})
+
+	return {
+		success: true,
+		breakEnd: now.toISOString(),
+		breakMinutes: totalBreakMinutes,
+		message: "休憩を終了しました",
 	}
 }
 
@@ -86,6 +162,8 @@ export async function getHistory(): Promise<HistoryResponse> {
 			clockIn: r.clockIn ? r.clockIn.toISOString() : null,
 			clockOut: r.clockOut ? r.clockOut.toISOString() : null,
 			workMinutes: r.workMinutes,
+			breaks: serializeBreaks(r.breaks),
+			breakMinutes: r.breakMinutes,
 		})),
 	}
 }

--- a/src/features/attendance/contracts/attendance.ts
+++ b/src/features/attendance/contracts/attendance.ts
@@ -1,7 +1,13 @@
 import { z } from "zod"
 
-export const AttendanceStatusSchema = z.enum(["not_started", "working", "finished"])
+export const AttendanceStatusSchema = z.enum(["not_started", "working", "on_break", "finished"])
 export type AttendanceStatus = z.infer<typeof AttendanceStatusSchema>
+
+export const BreakPeriodSchema = z.object({
+	breakStart: z.string(),
+	breakEnd: z.string().nullable(),
+})
+export type BreakPeriod = z.infer<typeof BreakPeriodSchema>
 
 export const TodayResponseSchema = z.object({
 	date: z.string(),
@@ -9,6 +15,8 @@ export const TodayResponseSchema = z.object({
 	clockIn: z.string().nullable(),
 	clockOut: z.string().nullable(),
 	workMinutes: z.number().nullable(),
+	breaks: z.array(BreakPeriodSchema),
+	breakMinutes: z.number().nullable(),
 })
 export type TodayResponse = z.infer<typeof TodayResponseSchema>
 
@@ -23,9 +31,25 @@ export const ClockOutResponseSchema = z.object({
 	success: z.boolean(),
 	clockOut: z.string().optional(),
 	workMinutes: z.number().optional(),
+	breakMinutes: z.number().optional(),
 	message: z.string(),
 })
 export type ClockOutResponse = z.infer<typeof ClockOutResponseSchema>
+
+export const BreakStartResponseSchema = z.object({
+	success: z.boolean(),
+	breakStart: z.string().optional(),
+	message: z.string(),
+})
+export type BreakStartResponse = z.infer<typeof BreakStartResponseSchema>
+
+export const BreakEndResponseSchema = z.object({
+	success: z.boolean(),
+	breakEnd: z.string().optional(),
+	breakMinutes: z.number().optional(),
+	message: z.string(),
+})
+export type BreakEndResponse = z.infer<typeof BreakEndResponseSchema>
 
 export const HistoryResponseSchema = z.object({
 	records: z.array(TodayResponseSchema),

--- a/src/features/attendance/domain/entities/attendance.ts
+++ b/src/features/attendance/domain/entities/attendance.ts
@@ -1,4 +1,9 @@
-export type AttendanceStatus = "not_started" | "working" | "finished"
+export type AttendanceStatus = "not_started" | "working" | "on_break" | "finished"
+
+export interface BreakPeriod {
+	breakStart: Date
+	breakEnd: Date | null // null = 休憩中
+}
 
 export interface AttendanceDay {
 	date: string // "2026-02-23" 形式
@@ -6,6 +11,8 @@ export interface AttendanceDay {
 	clockIn: Date | null
 	clockOut: Date | null
 	workMinutes: number | null
+	breaks: BreakPeriod[]
+	breakMinutes: number | null
 }
 
 export interface WorkDuration {

--- a/src/features/attendance/domain/logic/attendance.test.ts
+++ b/src/features/attendance/domain/logic/attendance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { AttendanceDay } from "../entities/attendance"
-import { canClockIn, canClockOut, getStatus } from "./attendance"
+import { canClockIn, canClockOut, canEndBreak, canStartBreak, getStatus } from "./attendance"
 
 const base: AttendanceDay = {
 	date: "2026-02-23",
@@ -8,6 +8,8 @@ const base: AttendanceDay = {
 	clockIn: null,
 	clockOut: null,
 	workMinutes: null,
+	breaks: [],
+	breakMinutes: null,
 }
 
 describe("canClockIn", () => {
@@ -16,6 +18,9 @@ describe("canClockIn", () => {
 	})
 	it("勤務中: false", () => {
 		expect(canClockIn({ ...base, status: "working" })).toBe(false)
+	})
+	it("休憩中: false", () => {
+		expect(canClockIn({ ...base, status: "on_break" })).toBe(false)
 	})
 	it("退勤済み: false", () => {
 		expect(canClockIn({ ...base, status: "finished" })).toBe(false)
@@ -29,8 +34,41 @@ describe("canClockOut", () => {
 	it("勤務中: true", () => {
 		expect(canClockOut({ ...base, status: "working" })).toBe(true)
 	})
+	it("休憩中: false", () => {
+		expect(canClockOut({ ...base, status: "on_break" })).toBe(false)
+	})
 	it("退勤済み: false", () => {
 		expect(canClockOut({ ...base, status: "finished" })).toBe(false)
+	})
+})
+
+describe("canStartBreak", () => {
+	it("未出勤: false", () => {
+		expect(canStartBreak({ ...base, status: "not_started" })).toBe(false)
+	})
+	it("勤務中: true", () => {
+		expect(canStartBreak({ ...base, status: "working" })).toBe(true)
+	})
+	it("休憩中: false", () => {
+		expect(canStartBreak({ ...base, status: "on_break" })).toBe(false)
+	})
+	it("退勤済み: false", () => {
+		expect(canStartBreak({ ...base, status: "finished" })).toBe(false)
+	})
+})
+
+describe("canEndBreak", () => {
+	it("未出勤: false", () => {
+		expect(canEndBreak({ ...base, status: "not_started" })).toBe(false)
+	})
+	it("勤務中: false", () => {
+		expect(canEndBreak({ ...base, status: "working" })).toBe(false)
+	})
+	it("休憩中: true", () => {
+		expect(canEndBreak({ ...base, status: "on_break" })).toBe(true)
+	})
+	it("退勤済み: false", () => {
+		expect(canEndBreak({ ...base, status: "finished" })).toBe(false)
 	})
 })
 
@@ -38,6 +76,7 @@ describe("getStatus", () => {
 	it("各ステータスをそのまま返す", () => {
 		expect(getStatus({ ...base, status: "not_started" })).toBe("not_started")
 		expect(getStatus({ ...base, status: "working" })).toBe("working")
+		expect(getStatus({ ...base, status: "on_break" })).toBe("on_break")
 		expect(getStatus({ ...base, status: "finished" })).toBe("finished")
 	})
 })

--- a/src/features/attendance/domain/logic/attendance.ts
+++ b/src/features/attendance/domain/logic/attendance.ts
@@ -8,6 +8,14 @@ export function canClockOut(today: AttendanceDay): boolean {
 	return today.status === "working"
 }
 
+export function canStartBreak(today: AttendanceDay): boolean {
+	return today.status === "working"
+}
+
+export function canEndBreak(today: AttendanceDay): boolean {
+	return today.status === "on_break"
+}
+
 export function getStatus(today: AttendanceDay): AttendanceStatus {
 	return today.status
 }

--- a/src/features/attendance/domain/logic/worktime.test.ts
+++ b/src/features/attendance/domain/logic/worktime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { calculateWorkDuration, formatDuration } from "./worktime"
+import { calculateTotalBreakMinutes, calculateWorkDuration, formatDuration } from "./worktime"
 
 describe("calculateWorkDuration", () => {
 	it("9:00〜18:00 → 540分", () => {
@@ -28,6 +28,43 @@ describe("calculateWorkDuration", () => {
 			new Date("2026-02-23T01:00:00+09:00"),
 		)
 		expect(result.totalMinutes).toBe(120)
+	})
+})
+
+describe("calculateTotalBreakMinutes", () => {
+	it("休憩なし → 0分", () => {
+		expect(calculateTotalBreakMinutes([])).toBe(0)
+	})
+
+	it("1回の休憩 60分", () => {
+		const breaks = [
+			{
+				breakStart: new Date("2026-02-23T12:00:00+09:00"),
+				breakEnd: new Date("2026-02-23T13:00:00+09:00"),
+			},
+		]
+		expect(calculateTotalBreakMinutes(breaks)).toBe(60)
+	})
+
+	it("2回の休憩 合計90分", () => {
+		const breaks = [
+			{
+				breakStart: new Date("2026-02-23T10:00:00+09:00"),
+				breakEnd: new Date("2026-02-23T10:30:00+09:00"),
+			},
+			{
+				breakStart: new Date("2026-02-23T12:00:00+09:00"),
+				breakEnd: new Date("2026-02-23T13:00:00+09:00"),
+			},
+		]
+		expect(calculateTotalBreakMinutes(breaks)).toBe(90)
+	})
+
+	it("休憩中（breakEnd が null）は now を使って計算する", () => {
+		const start = new Date("2026-02-23T12:00:00+09:00")
+		const now = new Date("2026-02-23T12:30:00+09:00")
+		const breaks = [{ breakStart: start, breakEnd: null }]
+		expect(calculateTotalBreakMinutes(breaks, now)).toBe(30)
 	})
 })
 

--- a/src/features/attendance/domain/logic/worktime.ts
+++ b/src/features/attendance/domain/logic/worktime.ts
@@ -1,4 +1,4 @@
-import type { WorkDuration } from "../entities/attendance"
+import type { BreakPeriod, WorkDuration } from "../entities/attendance"
 
 export function calculateWorkDuration(clockIn: Date, clockOut: Date): WorkDuration {
 	const totalMinutes = Math.floor((clockOut.getTime() - clockIn.getTime()) / 60000)
@@ -7,6 +7,14 @@ export function calculateWorkDuration(clockIn: Date, clockOut: Date): WorkDurati
 		minutes: totalMinutes % 60,
 		totalMinutes,
 	}
+}
+
+export function calculateTotalBreakMinutes(breaks: BreakPeriod[], now?: Date): number {
+	return breaks.reduce((total, b) => {
+		const end = b.breakEnd ?? now ?? new Date()
+		const minutes = Math.floor((end.getTime() - b.breakStart.getTime()) / 60000)
+		return total + Math.max(0, minutes)
+	}, 0)
 }
 
 export function formatDuration(minutes: number): string {

--- a/src/features/attendance/infrastructure/data/attendanceData.ts
+++ b/src/features/attendance/infrastructure/data/attendanceData.ts
@@ -7,34 +7,69 @@ export const initialHistory: AttendanceDay[] = [
 		status: "finished",
 		clockIn: new Date("2026-02-21T09:15:00+09:00"),
 		clockOut: new Date("2026-02-21T18:30:00+09:00"),
-		workMinutes: 555,
+		workMinutes: 495,
+		breaks: [
+			{
+				breakStart: new Date("2026-02-21T12:00:00+09:00"),
+				breakEnd: new Date("2026-02-21T13:00:00+09:00"),
+			},
+		],
+		breakMinutes: 60,
 	},
 	{
 		date: "2026-02-20",
 		status: "finished",
 		clockIn: new Date("2026-02-20T08:50:00+09:00"),
 		clockOut: new Date("2026-02-20T17:45:00+09:00"),
-		workMinutes: 535,
+		workMinutes: 475,
+		breaks: [
+			{
+				breakStart: new Date("2026-02-20T12:00:00+09:00"),
+				breakEnd: new Date("2026-02-20T13:00:00+09:00"),
+			},
+		],
+		breakMinutes: 60,
 	},
 	{
 		date: "2026-02-19",
 		status: "finished",
 		clockIn: new Date("2026-02-19T09:00:00+09:00"),
 		clockOut: new Date("2026-02-19T18:00:00+09:00"),
-		workMinutes: 540,
+		workMinutes: 480,
+		breaks: [
+			{
+				breakStart: new Date("2026-02-19T12:00:00+09:00"),
+				breakEnd: new Date("2026-02-19T13:00:00+09:00"),
+			},
+		],
+		breakMinutes: 60,
 	},
 	{
 		date: "2026-02-18",
 		status: "finished",
 		clockIn: new Date("2026-02-18T09:30:00+09:00"),
 		clockOut: new Date("2026-02-18T18:15:00+09:00"),
-		workMinutes: 525,
+		workMinutes: 465,
+		breaks: [
+			{
+				breakStart: new Date("2026-02-18T12:00:00+09:00"),
+				breakEnd: new Date("2026-02-18T13:00:00+09:00"),
+			},
+		],
+		breakMinutes: 60,
 	},
 	{
 		date: "2026-02-17",
 		status: "finished",
 		clockIn: new Date("2026-02-17T08:45:00+09:00"),
 		clockOut: new Date("2026-02-17T17:30:00+09:00"),
-		workMinutes: 525,
+		workMinutes: 465,
+		breaks: [
+			{
+				breakStart: new Date("2026-02-17T12:00:00+09:00"),
+				breakEnd: new Date("2026-02-17T13:00:00+09:00"),
+			},
+		],
+		breakMinutes: 60,
 	},
 ]

--- a/src/features/attendance/infrastructure/repositories/inMemoryAttendanceRepository.ts
+++ b/src/features/attendance/infrastructure/repositories/inMemoryAttendanceRepository.ts
@@ -9,6 +9,8 @@ let todayRecord: AttendanceDay = {
 	clockIn: null,
 	clockOut: null,
 	workMinutes: null,
+	breaks: [],
+	breakMinutes: null,
 }
 
 export class InMemoryAttendanceRepository implements AttendanceRepository {
@@ -20,13 +22,21 @@ export class InMemoryAttendanceRepository implements AttendanceRepository {
 				clockIn: null,
 				clockOut: null,
 				workMinutes: null,
+				breaks: [],
+				breakMinutes: null,
 			}
 		}
-		return { ...todayRecord }
+		return {
+			...todayRecord,
+			breaks: todayRecord.breaks.map((b) => ({ ...b })),
+		}
 	}
 
 	async save(record: AttendanceDay): Promise<void> {
-		todayRecord = { ...record }
+		todayRecord = {
+			...record,
+			breaks: record.breaks.map((b) => ({ ...b })),
+		}
 	}
 
 	async getHistory(): Promise<AttendanceDay[]> {

--- a/src/features/attendance/presentation/hooks/useAttendance.ts
+++ b/src/features/attendance/presentation/hooks/useAttendance.ts
@@ -3,6 +3,8 @@ import { fetchHistory } from "../../server-fns/history"
 import { fetchToday } from "../../server-fns/today"
 import { postClockIn } from "../../server-fns/clock-in"
 import { postClockOut } from "../../server-fns/clock-out"
+import { postBreakStart } from "../../server-fns/break-start"
+import { postBreakEnd } from "../../server-fns/break-end"
 
 export const QUERY_KEYS = {
 	today: ["attendance", "today"] as const,
@@ -37,6 +39,26 @@ export function useClockOut() {
 	const queryClient = useQueryClient()
 	return useMutation({
 		mutationFn: () => postClockOut(),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: ["attendance"] })
+		},
+	})
+}
+
+export function useStartBreak() {
+	const queryClient = useQueryClient()
+	return useMutation({
+		mutationFn: () => postBreakStart(),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: ["attendance"] })
+		},
+	})
+}
+
+export function useEndBreak() {
+	const queryClient = useQueryClient()
+	return useMutation({
+		mutationFn: () => postBreakEnd(),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["attendance"] })
 		},

--- a/src/features/attendance/presentation/parts/ClockButton.tsx
+++ b/src/features/attendance/presentation/parts/ClockButton.tsx
@@ -7,11 +7,20 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "#/components/ui/dialog"
-import { useClockIn, useClockOut } from "../hooks/useAttendance"
+import { useClockIn, useClockOut, useEndBreak, useStartBreak } from "../hooks/useAttendance"
 import type { AttendanceStatus } from "../../contracts/attendance"
 
 interface ClockButtonProps {
 	status: AttendanceStatus
+}
+
+type DialogAction = "clock-in" | "clock-out" | "break-start" | "break-end"
+
+const dialogConfig: Record<DialogAction, { title: string; confirmLabel: string }> = {
+	"clock-in": { title: "出勤しますか？", confirmLabel: "出勤する" },
+	"clock-out": { title: "退勤しますか？", confirmLabel: "退勤する" },
+	"break-start": { title: "休憩を開始しますか？", confirmLabel: "休憩開始" },
+	"break-end": { title: "休憩を終了しますか？", confirmLabel: "休憩終了" },
 }
 
 function formatCurrentTime(): string {
@@ -25,30 +34,34 @@ function formatCurrentTime(): string {
 
 export function ClockButton({ status }: ClockButtonProps) {
 	const [open, setOpen] = useState(false)
+	const [action, setAction] = useState<DialogAction>("clock-in")
 	const [currentTime, setCurrentTime] = useState("")
 
 	const clockIn = useClockIn()
 	const clockOut = useClockOut()
+	const startBreak = useStartBreak()
+	const endBreak = useEndBreak()
 
-	const isWorking = status === "working"
-	const isFinished = status === "finished"
+	const isPending =
+		clockIn.isPending || clockOut.isPending || startBreak.isPending || endBreak.isPending
 
-	function handleOpenDialog() {
+	function openDialog(a: DialogAction) {
+		setAction(a)
 		setCurrentTime(formatCurrentTime())
 		setOpen(true)
 	}
 
 	function handleConfirm() {
-		if (isWorking) {
-			clockOut.mutate(undefined, { onSettled: () => setOpen(false) })
-		} else {
-			clockIn.mutate(undefined, { onSettled: () => setOpen(false) })
-		}
+		const opts = { onSettled: () => setOpen(false) }
+		if (action === "clock-in") clockIn.mutate(undefined, opts)
+		else if (action === "clock-out") clockOut.mutate(undefined, opts)
+		else if (action === "break-start") startBreak.mutate(undefined, opts)
+		else endBreak.mutate(undefined, opts)
 	}
 
-	const isPending = clockIn.isPending || clockOut.isPending
+	const config = dialogConfig[action]
 
-	if (isFinished) {
+	if (status === "finished") {
 		return (
 			<p className="text-center text-sm text-muted-foreground py-4">
 				本日の打刻は完了しました
@@ -58,27 +71,58 @@ export function ClockButton({ status }: ClockButtonProps) {
 
 	return (
 		<>
-			<Button
-				onClick={handleOpenDialog}
-				disabled={isPending}
-				size="lg"
-				className={`w-full py-8 text-lg font-bold ${
-					isWorking
-						? "bg-red-500 hover:bg-red-600 text-white"
-						: "bg-green-500 hover:bg-green-600 text-white"
-				}`}
-			>
-				{isWorking ? "🔴 退勤する" : "🟢 出勤する"}
-			</Button>
+			<div className="space-y-3">
+				{status === "not_started" && (
+					<Button
+						onClick={() => openDialog("clock-in")}
+						disabled={isPending}
+						size="lg"
+						className="w-full py-8 text-lg font-bold bg-green-500 hover:bg-green-600 text-white"
+					>
+						🟢 出勤する
+					</Button>
+				)}
+
+				{status === "working" && (
+					<>
+						<Button
+							onClick={() => openDialog("break-start")}
+							disabled={isPending}
+							size="lg"
+							variant="outline"
+							className="w-full py-6 text-base font-bold border-yellow-400 text-yellow-700 hover:bg-yellow-50"
+						>
+							☕ 休憩開始
+						</Button>
+						<Button
+							onClick={() => openDialog("clock-out")}
+							disabled={isPending}
+							size="lg"
+							className="w-full py-8 text-lg font-bold bg-red-500 hover:bg-red-600 text-white"
+						>
+							🔴 退勤する
+						</Button>
+					</>
+				)}
+
+				{status === "on_break" && (
+					<Button
+						onClick={() => openDialog("break-end")}
+						disabled={isPending}
+						size="lg"
+						className="w-full py-8 text-lg font-bold bg-yellow-500 hover:bg-yellow-600 text-white"
+					>
+						☕ 休憩終了
+					</Button>
+				)}
+			</div>
 
 			<Dialog open={open} onOpenChange={setOpen}>
 				<DialogContent className="sm:max-w-sm">
 					<DialogHeader>
-						<DialogTitle>{isWorking ? "退勤しますか？" : "出勤しますか？"}</DialogTitle>
+						<DialogTitle>{config.title}</DialogTitle>
 					</DialogHeader>
-					<p className="text-center text-muted-foreground">
-						現在時刻: {currentTime}
-					</p>
+					<p className="text-center text-muted-foreground">現在時刻: {currentTime}</p>
 					<DialogFooter className="gap-2 sm:gap-0">
 						<Button variant="outline" onClick={() => setOpen(false)} disabled={isPending}>
 							キャンセル
@@ -87,12 +131,14 @@ export function ClockButton({ status }: ClockButtonProps) {
 							onClick={handleConfirm}
 							disabled={isPending}
 							className={
-								isWorking
+								action === "clock-out"
 									? "bg-red-500 hover:bg-red-600 text-white"
-									: "bg-green-500 hover:bg-green-600 text-white"
+									: action === "clock-in"
+										? "bg-green-500 hover:bg-green-600 text-white"
+										: "bg-yellow-500 hover:bg-yellow-600 text-white"
 							}
 						>
-							{isPending ? "処理中..." : isWorking ? "退勤する" : "出勤する"}
+							{isPending ? "処理中..." : config.confirmLabel}
 						</Button>
 					</DialogFooter>
 				</DialogContent>

--- a/src/features/attendance/presentation/parts/HistoryTable.tsx
+++ b/src/features/attendance/presentation/parts/HistoryTable.tsx
@@ -44,6 +44,7 @@ export function HistoryTable({ records }: HistoryTableProps) {
 					<TableHead>日付</TableHead>
 					<TableHead className="text-center">出勤</TableHead>
 					<TableHead className="text-center">退勤</TableHead>
+					<TableHead className="text-center">休憩</TableHead>
 					<TableHead className="text-right">勤務時間</TableHead>
 				</TableRow>
 			</TableHeader>
@@ -53,6 +54,11 @@ export function HistoryTable({ records }: HistoryTableProps) {
 						<TableCell className="font-medium">{formatDate(record.date)}</TableCell>
 						<TableCell className="text-center">{formatTime(record.clockIn)}</TableCell>
 						<TableCell className="text-center">{formatTime(record.clockOut)}</TableCell>
+						<TableCell className="text-center text-yellow-700">
+							{record.breakMinutes !== null && record.breakMinutes > 0
+								? formatDuration(record.breakMinutes)
+								: "-"}
+						</TableCell>
 						<TableCell className="text-right">
 							{record.workMinutes !== null ? formatDuration(record.workMinutes) : "-"}
 						</TableCell>

--- a/src/features/attendance/presentation/parts/StatusCard.tsx
+++ b/src/features/attendance/presentation/parts/StatusCard.tsx
@@ -20,6 +20,11 @@ const statusConfig = {
 		variant: "default" as const,
 		cardClass: "border-green-400 bg-green-50",
 	},
+	on_break: {
+		label: "☕ 休憩中",
+		variant: "secondary" as const,
+		cardClass: "border-yellow-400 bg-yellow-50",
+	},
 	finished: {
 		label: "✅ 退勤済み",
 		variant: "outline" as const,

--- a/src/features/attendance/presentation/parts/WorkSummary.tsx
+++ b/src/features/attendance/presentation/parts/WorkSummary.tsx
@@ -28,6 +28,14 @@ export function WorkSummary({ record }: WorkSummaryProps) {
 					<span className="font-medium">{formatTime(record.clockOut)}</span>
 				</div>
 			)}
+			{record.breakMinutes !== null && record.breakMinutes > 0 && (
+				<div className="flex justify-between">
+					<span className="text-muted-foreground">休憩時間</span>
+					<span className="font-medium text-yellow-700">
+						{formatDuration(record.breakMinutes)}
+					</span>
+				</div>
+			)}
 			{record.workMinutes !== null && (
 				<div className="flex justify-between">
 					<span className="text-muted-foreground">勤務時間</span>

--- a/src/features/attendance/server-fns/break-end.ts
+++ b/src/features/attendance/server-fns/break-end.ts
@@ -1,0 +1,4 @@
+import { createServerFn } from "@tanstack/react-start"
+import { endBreak } from "../application/services/attendanceService"
+
+export const postBreakEnd = createServerFn({ method: "POST" }).handler(endBreak)

--- a/src/features/attendance/server-fns/break-start.ts
+++ b/src/features/attendance/server-fns/break-start.ts
@@ -1,0 +1,4 @@
+import { createServerFn } from "@tanstack/react-start"
+import { startBreak } from "../application/services/attendanceService"
+
+export const postBreakStart = createServerFn({ method: "POST" }).handler(startBreak)


### PR DESCRIPTION
## Summary

- **新ステータス `on_break`** を追加し、出勤中 → 休憩中 → 勤務中 → 退勤済み のフローに対応
- **休憩開始 / 休憩終了ボタン** を UI に追加（確認ダイアログ付き）
- **複数回の休憩**に対応（`BreakPeriod[]` で管理）
- **退勤時の勤務時間**を正味（総勤務時間 - 累計休憩時間）で計算
- **履歴テーブルに休憩時間列**を追加
- **ステータスカード**で休憩中（☕ 黄色背景）を視覚的に表示

## 変更ファイル一覧

| レイヤー | 変更内容 |
|---|---|
| domain/entities | `BreakPeriod` 型、`on_break` ステータス、`AttendanceDay` に `breaks` / `breakMinutes` 追加 |
| domain/logic | `canStartBreak` / `canEndBreak` / `calculateTotalBreakMinutes` 追加 |
| contracts | `BreakPeriodSchema` / `BreakStartResponse` / `BreakEndResponse` 定義 |
| infrastructure | `inMemoryAttendanceRepository` / `attendanceData` を新フィールドに対応 |
| application/services | `startBreak` / `endBreak` ユースケース追加、`clockOut` で正味勤務時間を計算 |
| server-fns | `break-start.ts` / `break-end.ts` 新規作成 |
| presentation/hooks | `useStartBreak` / `useEndBreak` 追加 |
| presentation/parts | `ClockButton` / `StatusCard` / `WorkSummary` / `HistoryTable` を休憩機能に対応 |
| tests | `canStartBreak` / `canEndBreak` / `calculateTotalBreakMinutes` のテスト追加 |

## Test plan

- [ ] `pnpm test` — 全29テスト通過
- [ ] `npx tsc --noEmit` — 型エラー 0件
- [ ] `pnpm build` — ビルド成功
- [ ] 出勤 → 休憩開始 → 休憩終了 → 退勤 のフローが正常動作
- [ ] 複数回の休憩が累計で計算されること
- [ ] 勤務中のみ「休憩開始」ボタンが表示されること
- [ ] 休憩中は「休憩終了」ボタンのみ表示されること
- [ ] 退勤時の勤務時間が正味（休憩除外）で表示されること
- [ ] HistoryTable の休憩列に休憩時間が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)