### PR TITLE
feat(attendance): 退勤時に当日レコードを勤怠履歴に追加

### DIFF
--- a/src/features/attendance/infrastructure/repositories/inMemoryAttendanceRepository.ts
+++ b/src/features/attendance/infrastructure/repositories/inMemoryAttendanceRepository.ts
@@ -13,6 +13,9 @@ let todayRecord: AttendanceDay = {
 	breakMinutes: null,
 }
 
+// 退勤済みレコードを保持するマップ（日付 → レコード）
+const savedHistory: Map<string, AttendanceDay> = new Map()
+
 export class InMemoryAttendanceRepository implements AttendanceRepository {
 	async getToday(date: string): Promise<AttendanceDay> {
 		if (todayRecord.date !== date) {
@@ -37,9 +40,22 @@ export class InMemoryAttendanceRepository implements AttendanceRepository {
 			...record,
 			breaks: record.breaks.map((b) => ({ ...b })),
 		}
+		if (record.status === "finished") {
+			savedHistory.set(record.date, {
+				...record,
+				breaks: record.breaks.map((b) => ({ ...b })),
+			})
+		}
 	}
 
 	async getHistory(): Promise<AttendanceDay[]> {
-		return [...initialHistory]
+		const allRecords = new Map<string, AttendanceDay>()
+		for (const r of initialHistory) {
+			allRecords.set(r.date, r)
+		}
+		for (const [date, r] of savedHistory) {
+			allRecords.set(date, r)
+		}
+		return [...allRecords.values()].sort((a, b) => b.date.localeCompare(a.date))
 	}
 }


### PR DESCRIPTION
## 変更概要

退勤ボタンを押した際に、当日の勤怠記録が勤怠履歴テーブルに追加されるようにした。

## 変更点

- `InMemoryAttendanceRepository` に `savedHistory: Map<string, AttendanceDay>` を追加
- `save()` でステータスが `finished` のレコードを `savedHistory` に保存するよう変更
- `getHistory()` で `initialHistory` と `savedHistory` をマージし、日付降順で返すよう変更

## テスト内容

- [ ] 出勤 → 退勤の操作後、勤怠履歴に当日のレコードが追加されることを確認
- [ ] 休憩時間を含む出退勤でも、休憩・勤務時間が正しく履歴に反映されることを確認
- [ ] 既存の初期履歴データが引き続き表示されることを確認
- [ ] 同日付のレコードは重複せず上書きされることを確認（`Map` で管理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)