### PR TITLE
chore(claude): add pre-task git switch and pull rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,15 @@ Do NOT start coding until you have read both files completely.
 
 Every task MUST follow this workflow:
 
+### 0. 作業前の準備（必須）
+
+作業を開始する前に、必ず最新の `main` ブランチに切り替えて最新化する:
+
+```bash
+git switch main
+git pull origin main
+```
+
 ### 1. Issue の確認
 
 - GitHub Issue に基づくタスクの場合、`gh issue view <issue番号>` で内容を確認する


### PR DESCRIPTION
## 変更概要

作業開始前に必ず `git switch main` と `git pull origin main` を実行するルールを CLAUDE.md に追加。

## 変更点

- Git ワークフローに「### 0. 作業前の準備（必須）」を追加
- 作業開始前に `git switch main` → `git pull origin main` を実行することを必須化

## テスト内容

- CLAUDE.md の内容を目視確認済み