### PR TITLE
chore(claude): add pr-required rule as task completion definition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ Do NOT start coding until you have read both files completely.
 
 Every task MUST follow this workflow:
 
+> **作業完了の定義**: 実装が終わっても作業完了ではない。`gh pr create` で Pull Request を送信して初めて作業完了とする。PR なしで作業を終了してはならない。`main` への直接コミットも禁止。
+
 ### 0. 作業前の準備（必須）
 
 作業を開始する前に、必ず最新の `main` ブランチに切り替えて最新化する:


### PR DESCRIPTION
## 変更概要

作業完了の定義を明確化するルールを CLAUDE.md に追加。

## 変更点

- Git ワークフローセクションの冒頭に「作業完了の定義」を追記
  - 実装が終わっても作業完了ではない
  - `gh pr create` で PR を送信して初めて作業完了とする
  - PR なしで作業を終了してはならない
  - `main` への直接コミットも禁止

## 追加内容

```
> **作業完了の定義**: 実装が終わっても作業完了ではない。`gh pr create` で Pull Request を送信して初めて作業完了とする。PR なしで作業を終了してはならない。`main` への直接コミットも禁止。
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)