### PR TITLE
chore(claude): add Browser/Playwright MCP configuration for UI verification

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,5 +56,17 @@
       "Edit",
       "Write"
     ]
+  },
+  "mcpServers": {
+    "browser-playwright": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp@latest",
+        "--browser",
+        "chromium",
+        "--headless"
+      ]
+    }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "browser-playwright": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp@latest",
+        "--browser",
+        "chromium",
+        "--headless"
+      ],
+      "env": {
+        "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "0"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -41,6 +41,46 @@ chore(claude): [00:05:00] add pr-required rule as task completion definition
 ```
 
 
+## Browser/Playwright MCP（UI検証）の設定
+
+打刻ボタン、履歴テーブル、現在時刻表示などの **実ブラウザ検証** を行えるように、
+このリポジトリに MCP サーバー設定を追加しました。
+
+### 追加した設定
+
+- `.mcp.json`
+  - `browser-playwright` サーバーを定義
+  - `npx -y @playwright/mcp@latest --browser chromium --headless` で起動
+- `package.json` scripts
+  - `pnpm run mcp:browser`（headless）
+  - `pnpm run mcp:browser:headed`（headed）
+
+### 使い方
+
+1. 開発サーバーを起動
+
+```bash
+pnpm dev
+```
+
+2. MCP サーバーを起動
+
+```bash
+pnpm run mcp:browser
+```
+
+3. MCP 対応クライアント（Claude Code / Codex / Cursor など）で
+   `browser-playwright` サーバーに接続して UI 検証を実施
+
+### 確認観点の例
+
+- 打刻ボタン（出勤 / 退勤）がクリックできるか
+- 履歴テーブルが正しく表示されるか
+- 現在時刻表示が崩れずに更新されるか
+- スマホ幅でレイアウト崩れがないか
+
+
+
 # ディレクトリ構成
 
 ```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "format": "biome format",
     "lint": "biome lint",
     "check": "biome check",
-    "deploy": "pnpm run build && wrangler deploy"
+    "deploy": "pnpm run build && wrangler deploy",
+    "mcp:browser": "npx -y @playwright/mcp@latest --browser chromium --headless",
+    "mcp:browser:headed": "npx -y @playwright/mcp@latest --browser chromium"
   },
   "dependencies": {
     "@cloudflare/vite-plugin": "^1.13.8",


### PR DESCRIPTION
### Motivation
- Add a reproducible local MCP (Model Context Protocol) server configuration to enable real-browser UI verification of critical interactions like the clock-in/clock-out buttons, history table, and current time display. 
- Make it easy for agent-based tools (Claude/Codex/Cursor) and contributors to run headless or headed Playwright-backed browsers for visual/interaction checks. 

### Description
- Added a root `.mcp.json` that defines a `browser-playwright` MCP server using `npx -y @playwright/mcp@latest --browser chromium --headless`. 
- Added `mcp:browser` and `mcp:browser:headed` scripts to `package.json` to start the MCP server (`pnpm run mcp:browser` / `pnpm run mcp:browser:headed`). 
- Added the same `mcpServers.browser-playwright` entry to `.claude/settings.json` so Claude workflows can discover the server. 
- Documented the MCP setup, usage steps, and example verification checklist in `README.md` under a new "Browser/Playwright MCP（UI検証）の設定" section. 

### Testing
- Ran `pnpm test` (Vitest): all tests passed. 
- Ran `pnpm build` (Vite): build completed successfully. 
- Attempted `pnpm run mcp:browser -- --help` to validate the MCP script, but the command failed in this environment with `npm` registry `403 Forbidden`, so Playwright MCP execution could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ebc0ef088832fbff3780a8e3b9360)