### PR TITLE
docs: fix errors and add missing content in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ attendance-management-claude/
 │   │           ├── today.ts           # GET  /api/attendance/today
 │   │           ├── clock-in.ts        # POST /api/attendance/clock-in
 │   │           ├── clock-out.ts       # POST /api/attendance/clock-out
+│   │           ├── break-start.ts     # POST /api/attendance/break-start
+│   │           ├── break-end.ts       # POST /api/attendance/break-end
 │   │           └── history.ts         # GET  /api/attendance/history
 │   │
 │   ├── routes/
@@ -154,11 +156,22 @@ attendance-management-claude/
 │   │
 │   └── router.tsx       # TanStack Router 設定
 │
+├── e2e/
+│   └── attendance.spec.ts          # Playwright E2E テスト
+│
+├── docs/
+│   ├── effect-ts/                  # Effect.ts 段階的導入ログ（Option / pipe / Effect）
+│   ├── di/                         # 依存性注入パターン解説
+│   ├── hexagonal-architecture/     # ヘキサゴナルアーキテクチャ処理フロー解説
+│   └── test/                       # テスト解説（Vitest / React Testing Library / Playwright）
+│
 ├── prompts/
 │   ├── attendance-instructions.md  # Claude Code 向け実装指示書
 │   └── attendance-spec.md          # 実装仕様書（API仕様・型定義・UIイメージ等）
 │
-├── wrangler.jsonc       # Cloudflare Workers デプロイ設定
+├── playwright.config.ts  # Playwright 設定
+├── vitest.config.ts      # Vitest 設定
+├── wrangler.jsonc        # Cloudflare Workers デプロイ設定
 └── package.json
 ```
 
@@ -299,11 +312,22 @@ pnpm build
 
 ## Testing
 
-This project uses [Vitest](https://vitest.dev/) for testing. You can run the tests with:
+このプロジェクトは 3 つのテストレイヤーを持ちます。
+
+| レイヤー | フレームワーク | 対象 | コマンド |
+|---|---|---|---|
+| ユニット・コンポーネント | [Vitest](https://vitest.dev/) + [React Testing Library](https://testing-library.com/) | ドメインロジック・UI コンポーネント | `pnpm test` |
+| E2E | [Playwright](https://playwright.dev/) | ブラウザ上のユーザー操作 | `pnpm exec playwright test` |
 
 ```bash
+# ユニット・コンポーネントテストを実行
 pnpm test
+
+# E2E テストを実行（初回は dev サーバーが自動起動）
+pnpm exec playwright test
 ```
+
+テスト解説ドキュメント: [`docs/test/`](./docs/test/)
 
 ## Styling
 

--- a/docs/effect-ts/02-effect-typed-errors.md
+++ b/docs/effect-ts/02-effect-typed-errors.md
@@ -205,7 +205,7 @@ TypeScript は「AlreadyClockedInError を処理していない」とコンパ�
 // Effect<SuccessData, AlreadyClockedInError | NotWorkingError> になる
 Effect.flatMap(record =>
   canClockIn(record) ? Effect.succeed(record)
-  : canDoSomething(record) ? Effect.fail({ _tag: "NotWorkingError" } as const)
+  : canDoSomething(record) ? Effect.fail({ _tag: "NotWorking" } as const)
   : Effect.fail({ _tag: "AlreadyClockedIn" } as const)
 )
 ```


### PR DESCRIPTION
## 変更概要

README.md と docs/ 内のファイルを検証し、間違い・抜けを修正した。

## 修正点

### README.md

| 箇所 | 問題 | 修正内容 |
|---|---|---|
| ディレクトリ構成 `server-fns/` | `break-start.ts` と `break-end.ts` が実在するのに記載なし | 2ファイルを追加 |
| ディレクトリ構成 | `e2e/`、`docs/`、`playwright.config.ts`、`vitest.config.ts` が未記載 | 追加 |
| Testing セクション | Vitest のみ記載（RTL・Playwright が未記載） | 3層テスト構成の表とコマンドに更新 |

### docs/effect-ts/02-effect-typed-errors.md

| 箇所 | 問題 | 修正内容 |
|---|---|---|
| 仮想コード例（行208） | `_tag: "NotWorkingError"` と書いているが、同ファイル37行目の型定義は `_tag: "NotWorking"` で矛盾 | `"NotWorkingError"` → `"NotWorking"` に修正 |

## 検証済み

- 他の docs ファイル（di, hexagonal-architecture, effect-ts/01, test/\*）は実際のコードと一致していることを確認 ✅
- 修正後の README ディレクトリ構成が実際のファイル構造と一致していることを確認 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)