### PR TITLE
feat: カレンダーに日本の祝日表示とロケール分岐を追加

### DIFF
--- a/src/features/attendance/domain/logic/holiday.test.ts
+++ b/src/features/attendance/domain/logic/holiday.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { getHolidayNameByLocale } from "./holiday";
+
+describe("getHolidayNameByLocale", () => {
+	it("ja-JP locale のとき日本の祝日名を返す", () => {
+		const result = getHolidayNameByLocale(new Date(2026, 0, 1), "ja-JP");
+		expect(result).toBe("元日");
+	});
+
+	it("英語ロケールでは日本の祝日を返さない", () => {
+		const result = getHolidayNameByLocale(new Date(2026, 0, 1), "en-US");
+		expect(result).toBeNull();
+	});
+
+	it("日曜祝日の振替休日を返す", () => {
+		// 2029-02-11 (建国記念の日) は日曜日、翌 02-12 が振替休日
+		const result = getHolidayNameByLocale(new Date(2029, 1, 12), "ja");
+		expect(result).toBe("振替休日");
+	});
+});

--- a/src/features/attendance/domain/logic/holiday.ts
+++ b/src/features/attendance/domain/logic/holiday.ts
@@ -1,0 +1,167 @@
+const MONDAY = 1;
+const SUNDAY = 0;
+
+const holidayCache = new Map<number, Map<string, string>>();
+
+function toKey(month: number, day: number): string {
+	return `${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function getNthWeekdayOfMonth(
+	year: number,
+	monthIndex: number,
+	weekday: number,
+	nth: number,
+): number {
+	const firstDay = new Date(year, monthIndex, 1).getDay();
+	const offset = (weekday - firstDay + 7) % 7;
+	return 1 + offset + (nth - 1) * 7;
+}
+
+function getVernalEquinoxDay(year: number): number {
+	return Math.floor(
+		20.8431 + 0.242194 * (year - 1980) - Math.floor((year - 1980) / 4),
+	);
+}
+
+function getAutumnalEquinoxDay(year: number): number {
+	return Math.floor(
+		23.2488 + 0.242194 * (year - 1980) - Math.floor((year - 1980) / 4),
+	);
+}
+
+function addHoliday(
+	map: Map<string, string>,
+	month: number,
+	day: number,
+	name: string,
+): void {
+	map.set(toKey(month, day), name);
+}
+
+function createBaseJapaneseHolidays(year: number): Map<string, string> {
+	const map = new Map<string, string>();
+
+	addHoliday(map, 1, 1, "元日");
+
+	if (year >= 2000) {
+		addHoliday(map, 1, getNthWeekdayOfMonth(year, 0, MONDAY, 2), "成人の日");
+	} else {
+		addHoliday(map, 1, 15, "成人の日");
+	}
+
+	addHoliday(map, 2, 11, "建国記念の日");
+	if (year >= 2020) addHoliday(map, 2, 23, "天皇誕生日");
+
+	addHoliday(map, 3, getVernalEquinoxDay(year), "春分の日");
+	addHoliday(map, 4, 29, "昭和の日");
+	addHoliday(map, 5, 3, "憲法記念日");
+	addHoliday(map, 5, 4, "みどりの日");
+	addHoliday(map, 5, 5, "こどもの日");
+
+	if (year >= 2003) {
+		addHoliday(map, 7, getNthWeekdayOfMonth(year, 6, MONDAY, 3), "海の日");
+	} else if (year >= 1996) {
+		addHoliday(map, 7, 20, "海の日");
+	}
+
+	if (year >= 2016) {
+		addHoliday(map, 8, 11, "山の日");
+	}
+
+	if (year >= 2003) {
+		addHoliday(map, 9, getNthWeekdayOfMonth(year, 8, MONDAY, 3), "敬老の日");
+	} else if (year >= 1966) {
+		addHoliday(map, 9, 15, "敬老の日");
+	}
+
+	addHoliday(map, 9, getAutumnalEquinoxDay(year), "秋分の日");
+
+	if (year >= 2020) {
+		addHoliday(
+			map,
+			10,
+			getNthWeekdayOfMonth(year, 9, MONDAY, 2),
+			"スポーツの日",
+		);
+	} else if (year >= 2000) {
+		addHoliday(map, 10, getNthWeekdayOfMonth(year, 9, MONDAY, 2), "体育の日");
+	} else if (year >= 1966) {
+		addHoliday(map, 10, 10, "体育の日");
+	}
+
+	addHoliday(map, 11, 3, "文化の日");
+	addHoliday(map, 11, 23, "勤労感謝の日");
+
+	return map;
+}
+
+function createJapaneseHolidayMap(year: number): Map<string, string> {
+	const map = createBaseJapaneseHolidays(year);
+
+	for (let month = 1; month <= 12; month++) {
+		const daysInMonth = new Date(year, month, 0).getDate();
+		for (let day = 1; day <= daysInMonth; day++) {
+			const date = new Date(year, month - 1, day);
+			if (date.getDay() === SUNDAY && map.has(toKey(month, day))) {
+				let substituteDay = day + 1;
+				while (substituteDay <= daysInMonth) {
+					const key = toKey(month, substituteDay);
+					if (!map.has(key)) {
+						map.set(key, "振替休日");
+						break;
+					}
+					substituteDay += 1;
+				}
+			}
+		}
+	}
+
+	for (let month = 1; month <= 12; month++) {
+		const daysInMonth = new Date(year, month, 0).getDate();
+		for (let day = 2; day < daysInMonth; day++) {
+			const prevKey = toKey(month, day - 1);
+			const key = toKey(month, day);
+			const nextKey = toKey(month, day + 1);
+			const date = new Date(year, month - 1, day);
+
+			if (
+				date.getDay() !== SUNDAY &&
+				date.getDay() !== 6 &&
+				!map.has(key) &&
+				map.has(prevKey) &&
+				map.has(nextKey)
+			) {
+				map.set(key, "国民の休日");
+			}
+		}
+	}
+
+	return map;
+}
+
+function getJapaneseHolidayName(date: Date): string | null {
+	const year = date.getFullYear();
+	let map = holidayCache.get(year);
+	if (!map) {
+		map = createJapaneseHolidayMap(year);
+		holidayCache.set(year, map);
+	}
+
+	return map.get(toKey(date.getMonth() + 1, date.getDate())) ?? null;
+}
+
+function shouldUseJapaneseHoliday(locale: string): boolean {
+	const normalized = locale.toLowerCase();
+	return normalized.startsWith("ja") || normalized.endsWith("-jp");
+}
+
+export function getHolidayNameByLocale(
+	date: Date,
+	locale: string,
+): string | null {
+	if (shouldUseJapaneseHoliday(locale)) {
+		return getJapaneseHolidayName(date);
+	}
+	return null;
+}

--- a/src/features/attendance/presentation/AttendancePage.tsx
+++ b/src/features/attendance/presentation/AttendancePage.tsx
@@ -1,16 +1,21 @@
-import { Card, CardContent, CardHeader, CardTitle } from "#/components/ui/card"
-import { Separator } from "#/components/ui/separator"
-import { useAttendanceHistory, useTodayAttendance } from "./hooks/useAttendance"
-import { CalendarView } from "./parts/CalendarView"
-import { CurrentTime } from "./parts/CurrentTime"
-import { HistoryTable } from "./parts/HistoryTable"
-import { StatusCard } from "./parts/StatusCard"
-import { useViewModeStore } from "./store/viewModeStore"
+import { Card, CardContent, CardHeader, CardTitle } from "#/components/ui/card";
+import { Separator } from "#/components/ui/separator";
+import {
+	useAttendanceHistory,
+	useTodayAttendance,
+} from "./hooks/useAttendance";
+import { CalendarView } from "./parts/CalendarView";
+import { CurrentTime } from "./parts/CurrentTime";
+import { HistoryTable } from "./parts/HistoryTable";
+import { StatusCard } from "./parts/StatusCard";
+import { useViewModeStore } from "./store/viewModeStore";
 
 export function AttendancePage() {
-	const today = useTodayAttendance()
-	const history = useAttendanceHistory()
-	const { viewMode } = useViewModeStore()
+	const today = useTodayAttendance();
+	const history = useAttendanceHistory();
+	const { viewMode } = useViewModeStore();
+	const locale =
+		typeof navigator !== "undefined" ? navigator.language : "ja-JP";
 
 	return (
 		<div className="min-h-screen bg-background">
@@ -45,7 +50,9 @@ export function AttendancePage() {
 					</CardHeader>
 					<CardContent>
 						{history.isPending ? (
-							<p className="text-center text-muted-foreground py-4">読み込み中...</p>
+							<p className="text-center text-muted-foreground py-4">
+								読み込み中...
+							</p>
 						) : history.isError ? (
 							<p className="text-center text-destructive py-4">
 								履歴の取得に失敗しました
@@ -57,7 +64,10 @@ export function AttendancePage() {
 								<>
 									<HistoryTable records={history.data.records} />
 									<Separator className="my-4" />
-									<CalendarView records={history.data.records} />
+									<CalendarView
+										records={history.data.records}
+										locale={locale}
+									/>
 								</>
 							)
 						) : null}
@@ -65,5 +75,5 @@ export function AttendancePage() {
 				</Card>
 			</div>
 		</div>
-	)
+	);
 }

--- a/src/features/attendance/presentation/parts/CalendarView.test.tsx
+++ b/src/features/attendance/presentation/parts/CalendarView.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { CalendarView } from "./CalendarView";
+
+afterEach(() => {
+	cleanup();
+});
+
+const records = [
+	{
+		date: "2026-01-01",
+		status: "finished" as const,
+		clockIn: "2026-01-01T00:00:00.000Z",
+		clockOut: "2026-01-01T09:00:00.000Z",
+		workMinutes: 540,
+		breaks: [],
+		breakMinutes: 0,
+	},
+];
+
+describe("CalendarView", () => {
+	it("ja-JP locale では祝日名を表示する", () => {
+		render(
+			<CalendarView
+				records={records}
+				locale="ja-JP"
+				initialDate={new Date(2026, 0, 1)}
+			/>,
+		);
+		expect(screen.getByText("元日")).toBeDefined();
+	});
+
+	it("en-US locale では日本の祝日名を表示しない", () => {
+		render(
+			<CalendarView
+				records={records}
+				locale="en-US"
+				initialDate={new Date(2026, 0, 1)}
+			/>,
+		);
+		expect(screen.queryByText("元日")).toBeNull();
+	});
+});

--- a/src/features/attendance/presentation/parts/CalendarView.tsx
+++ b/src/features/attendance/presentation/parts/CalendarView.tsx
@@ -1,79 +1,105 @@
-import { ChevronLeft, ChevronRight } from "lucide-react"
-import { useState } from "react"
-import type { TodayResponse } from "../../contracts/attendance"
-import { formatDuration } from "../../domain/logic/worktime"
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import type { TodayResponse } from "../../contracts/attendance";
+import { getHolidayNameByLocale } from "../../domain/logic/holiday";
+import { formatDuration } from "../../domain/logic/worktime";
 
 interface CalendarViewProps {
-	records: TodayResponse[]
+	records: TodayResponse[];
+	locale?: string;
+	initialDate?: Date;
 }
 
-const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"] as const
+interface CalendarCell {
+	day: number | null;
+	key: string;
+}
+
+const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"] as const;
 
 // 曜日インデックスに対応するテキストカラーを返す
-function getDayTextClass(colIndex: number): string {
-	if (colIndex % 7 === 0) return "text-red-500"
-	if (colIndex % 7 === 6) return "text-blue-500"
-	return ""
+function getDayTextClass(dayOfWeek: number, isHoliday: boolean): string {
+	if (isHoliday) return "text-rose-600";
+	if (dayOfWeek === 0) return "text-red-500";
+	if (dayOfWeek === 6) return "text-blue-500";
+	return "";
 }
 
 // ステータスに応じた背景・ボーダーカラーを返す
 function getStatusBg(status: TodayResponse["status"]): string {
 	switch (status) {
 		case "finished":
-			return "bg-green-50 border-green-200"
+			return "bg-green-50 border-green-200";
 		case "working":
-			return "bg-blue-50 border-blue-200"
+			return "bg-blue-50 border-blue-200";
 		case "on_break":
-			return "bg-yellow-50 border-yellow-200"
+			return "bg-yellow-50 border-yellow-200";
 		default:
-			return "border-transparent"
+			return "border-transparent";
 	}
 }
 
-export function CalendarView({ records }: CalendarViewProps) {
-	const today = new Date()
-	const [year, setYear] = useState(today.getFullYear())
-	const [month, setMonth] = useState(today.getMonth()) // 0-indexed
+export function CalendarView({
+	records,
+	locale = "ja-JP",
+	initialDate,
+}: CalendarViewProps) {
+	const today = initialDate ?? new Date();
+	const [year, setYear] = useState(today.getFullYear());
+	const [month, setMonth] = useState(today.getMonth()); // 0-indexed
 
 	// date 文字列 → レコードの Map を作成（O(1) ルックアップ）
-	const recordMap = new Map(records.map((r) => [r.date, r]))
+	const recordMap = new Map(records.map((r) => [r.date, r]));
 
 	// 月の1日と日数を計算
-	const firstDay = new Date(year, month, 1)
-	const daysInMonth = new Date(year, month + 1, 0).getDate()
-	const startDow = firstDay.getDay() // 0 = 日曜日
+	const firstDay = new Date(year, month, 1);
+	const daysInMonth = new Date(year, month + 1, 0).getDate();
+	const startDow = firstDay.getDay(); // 0 = 日曜日
 
 	const prevMonth = () => {
 		if (month === 0) {
-			setYear(year - 1)
-			setMonth(11)
+			setYear(year - 1);
+			setMonth(11);
 		} else {
-			setMonth(month - 1)
+			setMonth(month - 1);
 		}
-	}
+	};
 
 	const nextMonth = () => {
 		if (month === 11) {
-			setYear(year + 1)
-			setMonth(0)
+			setYear(year + 1);
+			setMonth(0);
 		} else {
-			setMonth(month + 1)
+			setMonth(month + 1);
 		}
-	}
+	};
 
 	// カレンダーセルの配列: 月初前は null、各日は日付の数値
-	const cells: (number | null)[] = [
-		...Array(startDow).fill(null),
-		...Array.from({ length: daysInMonth }, (_, i) => i + 1),
-	]
+	const cells: CalendarCell[] = [
+		...Array.from({ length: startDow }, (_, i) => ({
+			day: null,
+			key: `leading-empty-${year}-${month}-${i}`,
+		})),
+		...Array.from({ length: daysInMonth }, (_, i) => ({
+			day: i + 1,
+			key: `day-${year}-${month + 1}-${i + 1}`,
+		})),
+	];
 	// 最終週を埋める
-	while (cells.length % 7 !== 0) cells.push(null)
+	const trailingEmptyCount = (7 - (cells.length % 7)) % 7;
+	cells.push(
+		...Array.from({ length: trailingEmptyCount }, (_, i) => ({
+			day: null,
+			key: `trailing-empty-${year}-${month}-${i}`,
+		})),
+	);
 
 	return (
 		<div>
 			{/* 月ナビゲーション */}
 			<div className="flex items-center justify-between mb-3">
 				<button
+					type="button"
 					onClick={prevMonth}
 					className="p-1.5 hover:bg-muted rounded-lg transition-colors"
 					aria-label="前の月"
@@ -84,6 +110,7 @@ export function CalendarView({ records }: CalendarViewProps) {
 					{year}年{month + 1}月
 				</span>
 				<button
+					type="button"
 					onClick={nextMonth}
 					className="p-1.5 hover:bg-muted rounded-lg transition-colors"
 					aria-label="次の月"
@@ -98,7 +125,11 @@ export function CalendarView({ records }: CalendarViewProps) {
 					<div
 						key={d}
 						className={`text-center text-xs font-medium py-1 ${
-							i === 0 ? "text-red-500" : i === 6 ? "text-blue-500" : "text-muted-foreground"
+							i === 0
+								? "text-red-500"
+								: i === 6
+									? "text-blue-500"
+									: "text-muted-foreground"
 						}`}
 					>
 						{d}
@@ -108,41 +139,59 @@ export function CalendarView({ records }: CalendarViewProps) {
 
 			{/* 日付セル */}
 			<div className="grid grid-cols-7 gap-0.5">
-				{cells.map((day, idx) => {
-					if (day === null) return <div key={`empty-${idx}`} className="min-h-[52px]" />
+				{cells.map((cell) => {
+					if (cell.day === null) {
+						return <div key={cell.key} className="min-h-[52px]" />;
+					}
 
-					const dateStr = `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`
-					const record = recordMap.get(dateStr)
+					const dateStr = `${year}-${String(month + 1).padStart(2, "0")}-${String(cell.day).padStart(2, "0")}`;
+					const date = new Date(year, month, cell.day);
+					const holidayName = getHolidayNameByLocale(date, locale);
+					const record = recordMap.get(dateStr);
 					const isToday =
-						day === today.getDate() &&
+						cell.day === today.getDate() &&
 						month === today.getMonth() &&
-						year === today.getFullYear()
+						year === today.getFullYear();
 
 					return (
 						<div
-							key={dateStr}
+							key={cell.key}
 							className={`rounded border min-h-[52px] p-1 text-xs ${
 								record ? getStatusBg(record.status) : "border-transparent"
 							} ${isToday ? "ring-2 ring-primary ring-offset-1" : ""}`}
 						>
-							<div className={`font-medium leading-none mb-1 ${getDayTextClass(idx)}`}>
-								{day}
+							<div
+								className={`font-medium leading-none mb-1 ${getDayTextClass(
+									date.getDay(),
+									holidayName !== null,
+								)}`}
+							>
+								{cell.day}
 							</div>
+							{holidayName && (
+								<div className="text-[10px] text-rose-600 leading-tight">
+									{holidayName}
+								</div>
+							)}
 							{record?.status === "finished" && record.workMinutes !== null && (
 								<div className="text-[10px] text-green-700 leading-tight">
 									{formatDuration(record.workMinutes)}
 								</div>
 							)}
 							{record?.status === "working" && (
-								<div className="text-[10px] text-blue-600 leading-tight">勤務中</div>
+								<div className="text-[10px] text-blue-600 leading-tight">
+									勤務中
+								</div>
 							)}
 							{record?.status === "on_break" && (
-								<div className="text-[10px] text-yellow-600 leading-tight">休憩中</div>
+								<div className="text-[10px] text-yellow-600 leading-tight">
+									休憩中
+								</div>
 							)}
 						</div>
-					)
+					);
 				})}
 			</div>
 		</div>
-	)
+	);
 }


### PR DESCRIPTION
### Motivation
- カレンダーに日本の祝日を表示し、平日と色を変えることで視認性を向上させるための機能追加です。将来的にロケールごとに祝日表示を切り替えやすい構造にします。

### Description
- 新規に `src/features/attendance/domain/logic/holiday.ts` を追加し、日本の固定祝日・ハッピーマンデー・春分/秋分（近似計算）・振替休日・国民の休日を判定する `getHolidayNameByLocale(date, locale)` を実装しました。
- `CalendarView` を拡張して `locale` / `initialDate` props を受け取り、`getHolidayNameByLocale` を利用して祝日名をセルに表示し、祝日の日付をローズ系の色で強調するようにしました。あわせて `button` に `type="button"` を追加し、カレンダーセルに安定したキー（年月ベースのキー）を付与して index キーの問題を解消しました。
- `AttendancePage` から `navigator.language` を `CalendarView` に渡すように変更し、実行環境のロケールで祝日表示を制御できるようにしました。
- テストを追加して祝日ロジック／表示の回帰を防止しました（`holiday.test.ts` と `CalendarView.test.tsx`）。

### Testing
- 実行した自動テスト: `pnpm test` を実行し、全テストが成功しました (`41 passed`).
- 変更対象ファイルの静的チェック: `pnpm exec biome check` を対象ファイルに対して実行し、該当ファイル群のチェックは成功しました.
- コード整形: `pnpm exec biome format --write` を実行して該当ファイルをフォーマットしました.
- 注記: リポジトリ全体に対する `pnpm check` は既存ファイルの別件の指摘が多く（今回の変更範囲外）、全体チェックで失敗していることを確認しましたが、今回の変更範囲に関するテストとチェックは通っています.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699efb7abb30832fa4a3db73f2df73db)